### PR TITLE
Feature: get status of all jobs

### DIFF
--- a/localq/Job.py
+++ b/localq/Job.py
@@ -40,6 +40,7 @@ class Job:
         try:
             self.start_time = now
             self.proc = subprocess.Popen(self.cmd,
+                                         shell=True,
                                          stdout=open(self.stdout, 'a'),
                                          stderr=open(self.stderr, 'a'),
                                          cwd=self.rundir)

--- a/localq/Job.py
+++ b/localq/Job.py
@@ -2,15 +2,9 @@ __author__ = 'dankle'
 import subprocess
 import os
 import datetime
+from localq.Status import Status
 
 class Job:
-
-    COMPLETED = "COMPLETED"
-    FAILED = "FAILED"
-    PENDING = "PENDING"
-    RUNNING = "RUNNING"
-    CANCELLED = "CANCELLED"
-    NOT_FOUND = "NOT_FOUND"
 
     """ A command line job to run with a specified number of cores
     """
@@ -26,7 +20,7 @@ class Job:
         self._failed_to_start = False
         self.start_time = None
         self.end_time = None
-        self._status = Job.PENDING
+        self._status = Status.PENDING
         if name is not None:
             self.name = name
         else:
@@ -67,46 +61,46 @@ class Job:
                 self.proc.kill()
             except OSError:  # if job is finished or has been cancelled before, an OSError will be thrown
                 pass
-        self._status = Job.CANCELLED
+        self._status = Status.CANCELLED
 
     def update_status(self):
         """
         update the jobs status. Returns nothing.
         :return:
         """
-        if self._status == Job.CANCELLED:
+        if self._status == Status.CANCELLED:
             pass
         elif self.proc:
             # update the process' returncode
             self.proc.poll()
 
             if self.proc.returncode is None:  # Running
-                self._status = Job.RUNNING
+                self._status = Status.RUNNING
 
             else:  # None < 0 evaluates as True on some systems, so need to make sure its not None
                 if self.proc.returncode == 0:  # Completed successfully
                     if not self.end_time:
                         self.end_time = self._get_formatted_now()
-                    self._status = Job.COMPLETED
+                    self._status = Status.COMPLETED
 
                 elif self.proc.returncode > 0:  # Failed
                     if not self.end_time:
                         self.end_time = self._get_formatted_now()
-                    self._status = Job.FAILED
+                    self._status = Status.FAILED
 
                 elif self.proc.returncode < 0:  # Cancelled
                     if not self.end_time:
                         self.end_time = self._get_formatted_now()
                     # if job was cancelled, returncode will be -N if it received signal N (SIGKILL = 9)
-                    self._status = Job.CANCELLED
+                    self._status = Status.CANCELLED
         else:
             if self._failed_to_start: # Failed to start (self.proc will equal None if this happens)
                 if not self.end_time:
                     self.end_time = self._get_formatted_now()
-                self._status = Job.FAILED
+                self._status = Status.FAILED
 
             else:
-                self._status = Job.PENDING
+                self._status = Status.PENDING
 
     def status(self):
         """

--- a/localq/Job.py
+++ b/localq/Job.py
@@ -40,7 +40,6 @@ class Job:
         try:
             self.start_time = now
             self.proc = subprocess.Popen(self.cmd,
-                                         shell=True,
                                          stdout=open(self.stdout, 'a'),
                                          stderr=open(self.stderr, 'a'),
                                          cwd=self.rundir)

--- a/localq/LocalQServer.py
+++ b/localq/LocalQServer.py
@@ -38,6 +38,15 @@ class LocalQServer():
         self._last_jobid += 1
         return self._last_jobid
 
+    def get_status_all(self):
+        """
+        Get the status of all know jobs.
+        :return: a dict with job-ids as keys, and their status as values.
+        """
+        jobs_and_status = map(lambda job: (job.jobid, job.status()), self.jobs)
+        print(jobs_and_status)
+        return dict(jobs_and_status)
+
     def list_queue(self):
         retstr = "JOBID\tPRIO\tSTATUS\tNUM_CORES\tSTART_TIME\tEND_TIME\tNAME\tCMD\n"
         for j in self.jobs:

--- a/localq/LocalQServer.py
+++ b/localq/LocalQServer.py
@@ -6,7 +6,7 @@ import time
 import threading
 import localq
 from operator import methodcaller
-
+from localq.Status import Status
 
 class LocalQServer():
     def __init__(self, num_cores_available, interval, priority_method):
@@ -57,7 +57,7 @@ class LocalQServer():
         """
         Check in which state (list) a job is.
         :param jobid: a job id to search for
-        :return: Any of Job.PENDING, RUNNING, COMPLETED or FAILED.
+        :return: Any of Status.PENDING, RUNNING, COMPLETED or FAILED.
         If no job with the given ID is found, Job.NOT_FOUND is returned.
         """
         job = self.get_job_with_id(int(jobid))
@@ -97,14 +97,14 @@ class LocalQServer():
 
         def get_n_cores_booked():
             n_cores_booked = 0
-            running_jobs = [j for j in self.jobs if j.status() == localq.Job.RUNNING]
+            running_jobs = [j for j in self.jobs if j.status() == Status.RUNNING]
             for job in running_jobs:
                 n_cores_booked += job.num_cores
             return n_cores_booked
 
         def check_queue():
             while True:
-                pending_jobs = [j for j in self.jobs if j.status() == localq.Job.PENDING]
+                pending_jobs = [j for j in self.jobs if j.status() == Status.PENDING]
                 pending_jobs = sorted(pending_jobs, key=methodcaller('priority'), reverse=True)
 
                 # check if new jobs can be started

--- a/localq/LocalQServer.py
+++ b/localq/LocalQServer.py
@@ -77,12 +77,12 @@ class LocalQServer():
         """
         stop a job with a give ID
         :param jobid: Job ID of job to stop
-        :return: the jobs new ID after it was tried to be stopped
+        :return: the jobs new ID after it was tried to be stopped (None if it can not find the job)
         """
         job = self.get_job_with_id(int(jobid))
         if job:
             job.kill()
-            return 1
+            return jobid
         else:
             return None
 

--- a/localq/LocalQServer.py
+++ b/localq/LocalQServer.py
@@ -58,13 +58,13 @@ class LocalQServer():
         Check in which state (list) a job is.
         :param jobid: a job id to search for
         :return: Any of Status.PENDING, RUNNING, COMPLETED or FAILED.
-        If no job with the given ID is found, Job.NOT_FOUND is returned.
+        If no job with the given ID is found, Status.NOT_FOUND is returned.
         """
         job = self.get_job_with_id(int(jobid))
         if job:
             return job.status()
         else:
-            return localq.Job.NOT_FOUND
+            return Status.NOT_FOUND
 
     def get_job_with_id(self, jobid):
         jobs = [job for job in self.jobs if job.jobid == jobid]

--- a/localq/Status.py
+++ b/localq/Status.py
@@ -1,0 +1,10 @@
+__author__ = 'johda411'
+
+
+class Status:
+    COMPLETED = "COMPLETED"
+    FAILED = "FAILED"
+    PENDING = "PENDING"
+    RUNNING = "RUNNING"
+    CANCELLED = "CANCELLED"
+    NOT_FOUND = "NOT_FOUND"

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -1,19 +1,22 @@
 __author__ = 'dankle'
 
-import pytest
+import unittest
 import localq.Job
+from localq.Status import Status
 
-def test_job():
-    job = localq.Job(["ls", "-la"], num_cores=1, name="testjob")
-    job.set_jobid(1)
-    assert job.num_cores == 1
-    assert job.cmd == ["ls", "-la"]
-    assert job.jobid == 1
-    assert job.status() == localq.Job.PENDING
-    assert job.priority_method == "fifo"
-    assert job.priority() == -1
-    assert job.name == "testjob"
-    job.kill()
-    assert job.status() == localq.Job.CANCELLED
+class TestJob(unittest.TestCase):
 
-    #def __init__(self, cmd, num_cores=1, stdout=None, stderr=None, priority_method="fifo", rundir=None):
+    def test_job(self):
+        job = localq.Job(["ls", "-la"], num_cores=1, name="testjob")
+        job.set_jobid(1)
+        assert job.num_cores == 1
+        assert job.cmd == ["ls", "-la"]
+        assert job.jobid == 1
+        assert job.status() == Status.PENDING
+        assert job.priority_method == "fifo"
+        assert job.priority() == -1
+        assert job.name == "testjob"
+        job.kill()
+        assert job.status() == Status.CANCELLED
+
+        #def __init__(self, cmd, num_cores=1, stdout=None, stderr=None, priority_method="fifo", rundir=None):

--- a/tests/test_localq_server.py
+++ b/tests/test_localq_server.py
@@ -1,29 +1,41 @@
 __author__ = 'dankle'
 
-import pytest
+import unittest
 import localq
+from localq.Status import Status
 
-def test_server():
-    #LocalQServer(num_cores, interval, priority_type)
-    server = localq.LocalQServer(1, 60, "fifo")
-
-    # add(cmd, num_cores)
-    server.add(["ls", "-la"], 1)
-    server.add(["ls", "-lah"], 2)
-
-    assert len(server.jobs) == 1  # since job2 requests 2 cores, but only 1 is available
-
-    server.add(["ls", "-lah"], 1)
-
-    assert len(server.jobs) == 2  # since job2 requests 2 cores, but only 1 is available
-
-    assert server.jobs[0].jobid == 1
-    assert server.get_status(1) == localq.Job.PENDING
-    server.stop_job_with_id(1)
-    assert server.get_status(1) == localq.Job.CANCELLED
-    server.stop_all_jobs()
-    assert server.get_status(2) == localq.Job.CANCELLED
+class TestLocalQServer(unittest.TestCase):
 
 
+    def test_server(self):
+        #LocalQServer(num_cores, interval, priority_type)
+        server = localq.LocalQServer(1, 60, "fifo")
 
-    #num_cores_available, interval, priority_method
+        # add(cmd, num_cores)
+        server.add(["ls", "-la"], 1)
+        server.add(["ls", "-lah"], 2)
+
+        assert len(server.jobs) == 1  # since job2 requests 2 cores, but only 1 is available
+
+        server.add(["ls", "-lah"], 1)
+
+        assert len(server.jobs) == 2  # since job2 requests 2 cores, but only 1 is available
+
+        assert server.jobs[0].jobid == 1
+        assert server.get_status(1) == Status.PENDING
+        server.stop_job_with_id(1)
+        assert server.get_status(1) == Status.CANCELLED
+        server.stop_all_jobs()
+        assert server.get_status(2) == Status.CANCELLED
+
+        #num_cores_available, interval, priority_method
+
+    def test_get_status_for_all(self):
+        server = localq.LocalQServer(1, 60, "fifo")
+
+        server.add(["sleep 3"], 1)
+        server.add(["sleep 3"], 1)
+        server.add(["sleep 3"], 1)
+
+        jobs = server.get_status_all()
+        self.assertEqual(jobs, {1 : Status.PENDING, 2 : Status.PENDING, 3 : Status.PENDING})


### PR DESCRIPTION
I added a small feature to get the status of all currently running jobs.

I also:
 - did some refactoring of the tests
 - pulled out `Status` from job into it's own class to make it easier to reuse.
 - fixed a bug (or at least a deviation for the doc) for `stop_jobs_with_id`

I'm still very much a beginner in python so any feedback would be very welcome.