### PR TITLE
Kill entire process group to make child processes die when present

### DIFF
--- a/localq/Job.py
+++ b/localq/Job.py
@@ -1,7 +1,11 @@
-__author__ = 'dankle'
+import os
+import signal
 import subprocess
 import datetime
 from localq.Status import Status
+
+__author__ = 'dankle'
+
 
 class Job:
 
@@ -40,7 +44,9 @@ class Job:
                                          shell=self.use_shell,
                                          stdout=open(self.stdout, 'a'),
                                          stderr=open(self.stderr, 'a'),
-                                         cwd=self.rundir)
+                                         cwd=self.rundir,
+                                         preexec_fn=os.setsid
+                                         )
         except OSError:
             # An OSError is thrown if the executable file in 'cmd' is not found. This needs to be captured
             # "manually" and handled in self.status()
@@ -56,7 +62,7 @@ class Job:
         """
         if self.proc:
             try:
-                self.proc.terminate() # sends the SIGTERM signal
+                os.killpg(os.getpgid(self.proc.pid), signal.SIGTERM)
             except OSError:  # if job is finished or has been cancelled before, an OSError will be thrown
                 pass
         self._status = Status.CANCELLED

--- a/tests/test_localq_Job.py
+++ b/tests/test_localq_Job.py
@@ -48,12 +48,10 @@ class TestJob(unittest.TestCase):
     def test_kill(self):
         self.job.proc = MagicMock()
         self.job.kill()
-        self.job.proc.terminate.assert_called_with()
         assert self.job._status == Status.CANCELLED
 
         self.job.proc.kill = MagicMock(side_effect=OSError("foo"))
         self.job.kill()
-        self.job.proc.terminate.assert_called_with()
         assert self.job._status == Status.CANCELLED
 
     def test_run(self):


### PR DESCRIPTION
Instead of issuing `Popen.kill()` which only terminates the process in question, this uses `os.killpg()` to kill the whole process group which includes child process. This is useful when a script is added, which in turn spawn a set of processes.

@johandahlberg I had to remove `self.job.proc.terminate.assert_called_with()` from the tests. I'm not sure what an appropriate replacement would be.