### PR TITLE
Fixed write_dot import to make mocking work

### DIFF
--- a/localq/localQ_server.py
+++ b/localq/localQ_server.py
@@ -7,7 +7,7 @@ import threading
 
 import sys
 
-from networkx.drawing.nx_pydot import write_dot
+import networkx.drawing.nx_pydot as nx_pydot
 
 from localq.status import Status
 import networkx as nx
@@ -193,7 +193,7 @@ class LocalQServer():
         :param f: file to write
         :return: None
         """
-        write_dot(self.graph, f)
+        nx_pydot.write_dot(self.graph, f)
 
     def get_ordered_jobs(self):
         """ Method to order the tasks in the pipeline


### PR DESCRIPTION
Importing the function straight from the module made mocking more difficult. So I changed this to import the module and then explicitly call the method. I also think that this is clearer - but that I guess is a matter of taste.