### PR TITLE
use bash when running scripts.

### DIFF
--- a/localq/localQ_server.py
+++ b/localq/localQ_server.py
@@ -61,7 +61,7 @@ class LocalQServer():
             return job.jobid
 
     def add_script(self, script, num_cores, rundir=".", stdout=None, stderr=None, name=None, dependencies=None):
-        cmd = ["sh", script]
+        cmd = ["bash", script]
         return self.add(cmd, num_cores, stdout=stdout, stderr=stderr, rundir=rundir, name=name,
                         dependencies=dependencies)
 


### PR DESCRIPTION
This allows for scripts to use bashisms such as `<( )` and unofficial bash strict mode (`set -euo pipefail`) on distros that use `dash` as the default `sh`. 